### PR TITLE
fix: Update the peripheraldevice api methods to the latest typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,9 @@
   "dependencies": {
     "clone": "^2.1.2",
     "googleapis": "^37.2.0",
-    "tv-automation-server-core-integration": "^0.8.0",
+    "timeline-state-resolver-types": "^2.1.0",
+    "tv-automation-server-core-integration": "^1.0.0",
+    "tv-automation-sofie-blueprints-integration": "^0.21.0",
     "underscore": "^1.9.1",
     "uuid": "^3.3.2",
     "winston": "^2.4.2"

--- a/src/mutate.ts
+++ b/src/mutate.ts
@@ -1,0 +1,33 @@
+import * as _ from 'underscore'
+import { SheetRunningOrder } from './classes/RunningOrder'
+import { IngestRundown, IngestSegment, IngestPart } from 'tv-automation-sofie-blueprints-integration'
+import { SheetSection } from './classes/Section'
+import { SheetStory } from './classes/Story'
+
+/** These are temorary mutation functions to convert sheet types to ingest types */
+export function mutateRundown (rundown: SheetRunningOrder): IngestRundown {
+	return {
+		externalId: rundown.id,
+		name: rundown.name,
+		type: 'external',
+		payload: _.omit(rundown, 'sections'),
+		segments: _.values(rundown.sections || {}).map(mutateSegment)
+	}
+}
+export function mutateSegment (segment: SheetSection): IngestSegment {
+	return {
+		externalId: segment.id,
+		name: segment.name,
+		rank: segment.rank,
+		payload: _.omit(segment, 'stories'),
+		parts: _.values(segment.stories || {}).map(mutatePart)
+	}
+}
+export function mutatePart (part: SheetStory): IngestPart {
+	return {
+		externalId: part.id,
+		name: part.name,
+		rank: part.rank,
+		payload: part
+	}
+}

--- a/src/spreadsheetHandler.ts
+++ b/src/spreadsheetHandler.ts
@@ -9,6 +9,7 @@ import { OAuth2Client } from 'google-auth-library'
 
 import { CoreHandler } from './coreHandler'
 import { RunningOrderWatcher } from './classes/RunningOrderWatcher'
+import { mutateRundown, mutateSegment, mutatePart } from './mutate'
 
 export interface SpreadsheetConfig {
 	// Todo: add settings here?
@@ -267,32 +268,33 @@ export class SpreadsheetHandler {
 					.on('warning', (warning: any) => {
 						this._logger.error(warning)
 					})
+					// TODO - these event types should operate on the correct types and with better parameters
 					.on('runningOrder_delete', (runningOrderId) => {
-						this._coreHandler.core.callMethod(P.methods.dataRunningOrderDelete, [runningOrderId]).catch(this._logger.error)
+						this._coreHandler.core.callMethod(P.methods.dataRundownDelete, [runningOrderId]).catch(this._logger.error)
 					})
 					.on('runningOrder_create', (runningOrderId, runningOrder) => {
-						this._coreHandler.core.callMethod(P.methods.dataRunningOrderCreate, [runningOrderId, runningOrder]).catch(this._logger.error)
+						this._coreHandler.core.callMethod(P.methods.dataRundownCreate, [mutateRundown(runningOrder)]).catch(this._logger.error)
 					})
 					.on('runningOrder_update', (runningOrderId, runningOrder) => {
-						this._coreHandler.core.callMethod(P.methods.dataRunningOrderUpdate, [runningOrderId, runningOrder]).catch(this._logger.error)
+						this._coreHandler.core.callMethod(P.methods.dataRundownUpdate, [mutateRundown(runningOrder)]).catch(this._logger.error)
 					})
 					.on('section_delete', (runningOrderId, sectionId) => {
 						this._coreHandler.core.callMethod(P.methods.dataSegmentDelete, [runningOrderId, sectionId]).catch(this._logger.error)
 					})
 					.on('section_create', (runningOrderId, sectionId, newSection) => {
-						this._coreHandler.core.callMethod(P.methods.dataSegmentCreate, [runningOrderId, sectionId, newSection]).catch(this._logger.error)
+						this._coreHandler.core.callMethod(P.methods.dataSegmentCreate, [runningOrderId, mutateSegment(newSection)]).catch(this._logger.error)
 					})
 					.on('section_update', (runningOrderId, sectionId, newSection) => {
-						this._coreHandler.core.callMethod(P.methods.dataSegmentUpdate, [runningOrderId, sectionId, newSection]).catch(this._logger.error)
+						this._coreHandler.core.callMethod(P.methods.dataSegmentUpdate, [runningOrderId, mutateSegment(newSection)]).catch(this._logger.error)
 					})
 					.on('story_delete', (runningOrderId, sectionId, storyId) => {
-						this._coreHandler.core.callMethod(P.methods.dataSegmentLineItemDelete, [runningOrderId, sectionId, storyId]).catch(this._logger.error)
+						this._coreHandler.core.callMethod(P.methods.dataPartDelete, [runningOrderId, sectionId, storyId]).catch(this._logger.error)
 					})
 					.on('story_create', (runningOrderId, sectionId, storyId, newStory) => {
-						this._coreHandler.core.callMethod(P.methods.dataSegmentLineItemCreate, [runningOrderId, sectionId, storyId, newStory]).catch(this._logger.error)
+						this._coreHandler.core.callMethod(P.methods.dataPartCreate, [runningOrderId, sectionId, mutatePart(newStory)]).catch(this._logger.error)
 					})
 					.on('story_update', (runningOrderId, sectionId, storyId, newStory) => {
-						this._coreHandler.core.callMethod(P.methods.dataSegmentLineItemUpdate, [runningOrderId, sectionId, storyId, newStory]).catch(this._logger.error)
+						this._coreHandler.core.callMethod(P.methods.dataPartUpdate, [runningOrderId, sectionId, mutatePart(newStory)]).catch(this._logger.error)
 					})
 
 					this._logger.info(`Starting watch of folder "${settings.folderPath}"`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4072,17 +4072,17 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-mime-db@~1.38.0:
-  version "1.38.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
-  integrity sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==
+mime-db@1.40.0:
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
+  integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
 
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19:
-  version "2.1.22"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.22.tgz#fe6b355a190926ab7698c9a0556a11199b2199bd"
-  integrity sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==
+  version "2.1.24"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
+  integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
   dependencies:
-    mime-db "~1.38.0"
+    mime-db "1.40.0"
 
 mime@^2.2.0:
   version "2.4.0"
@@ -4163,6 +4163,11 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
+
+moment@^2.22.2:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 mount-point@^3.0.0:
   version "3.0.0"
@@ -5807,6 +5812,13 @@ timed-out@^3.0.0:
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-3.1.3.tgz#95860bfcc5c76c277f8f8326fd0f5b2e20eba217"
   integrity sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=
 
+timeline-state-resolver-types@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-2.1.0.tgz#a9bad5340f74c2e8f1a43b57702b045919a2d80c"
+  integrity sha512-1atRDzgB49w0TE+hpZVxHwZOMCMwB1jV6IJlUkmV/ni6iQLgTSBzN6xvHxgZAZNRY7nbLTmR6938hYOAJ8S0JQ==
+  dependencies:
+    tslib "^1.9.3"
+
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
@@ -6009,16 +6021,25 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-tv-automation-server-core-integration@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/tv-automation-server-core-integration/-/tv-automation-server-core-integration-0.8.0.tgz#81087d46d8de6dc533fecd35bbda7050e01c9bfd"
-  integrity sha512-d/ydaPP+RxuOentEb4QSvDrYhG6B5uibrk9Q3/VXG5tvsmWEFKjaJCvjH6DKJmNgF+fpCSv4zp+6B0NpNJ+E9g==
+tv-automation-server-core-integration@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tv-automation-server-core-integration/-/tv-automation-server-core-integration-1.0.1.tgz#530dc1ba43a19ef8496bdb4f5af38cff8b2f3154"
+  integrity sha512-gjwoOQQew7Ob30ZnIFbibP9s6/ziEApDVNkwvmzSzPNiqoqqGnWv/iBUi93GyvkcDQZwuMHFwtWOlyw1n1a99A==
   dependencies:
     data-store "3.1.0"
     ddp "git+http://github.com/nytamin/node-ddp-client.git#v0.12.2-next2"
     ddp-ejson "~0.8.1-3"
     ddp-random "~0.8.1-1"
     request "^2.88.0"
+    tslib "^1.9.3"
+    underscore "^1.9.1"
+
+tv-automation-sofie-blueprints-integration@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/tv-automation-sofie-blueprints-integration/-/tv-automation-sofie-blueprints-integration-0.21.0.tgz#0ef24c46978e247808cd614cf6228096dda0d4dd"
+  integrity sha512-3J8/XWxu7aF7F/Ng5j8HY/UXXh2WSvhupxkcS2ZGXsbh5n9A+meCvNU+pTM6mfPqkIgR+JxAbLy2Fog0vKaYNg==
+  dependencies:
+    moment "^2.22.2"
     tslib "^1.9.3"
     underscore "^1.9.1"
 


### PR DESCRIPTION
This slightly hackily updates the peripheral device api to current core develop.
It also updates it to send the Ingest types, allowing the temporary mutations added there (https://github.com/nrkno/tv-automation-server-core/blob/d03eb7903afebcf00acd6adefc97890d33b731d4/meteor/server/api/ingest/ingest.ts#L7) to be removed

It could be done cleaner by generating the Ingest types more natively, but this is a quick fix just so that it works for now